### PR TITLE
better email naming definition

### DIFF
--- a/__test__/uca/UserCollectableAttributes.test.js
+++ b/__test__/uca/UserCollectableAttributes.test.js
@@ -254,9 +254,9 @@ describe('UCA Constructions tests', () => {
 
   test('Construct a cvc:Contact:email UCA', () => {
     const identifier = 'cvc:Contact:email';
-    const email = new UCA(identifier, { address: 'joao', domain: { local_part: 'civic', tld: 'com' } });
+    const email = new UCA(identifier, { username: 'joao', domain: { local_part: 'civic', tld: 'com' } });
     const plain = email.getPlainValue();
-    expect(plain.address).toBe('joao');
+    expect(plain.username).toBe('joao');
     expect(plain.domain).toBeDefined();
     expect(plain.domain.local_part).toBe('civic');
     expect(plain.domain.tld).toBe('com');
@@ -305,7 +305,7 @@ describe('UCA Constructions tests', () => {
     const emailDefinition = _.find(definitions, { identifier: 'cvc:Contact:email' });
     const properties = UCA.getUCAProperties(emailDefinition);
     expect(properties).toHaveLength(3);
-    expect(properties).toContain('email.address');
+    expect(properties).toContain('email.username');
     expect(properties).toContain('email.domain.local_part');
     expect(properties).toContain('email.domain.tld');
   });

--- a/src/uca/definitions.js
+++ b/src/uca/definitions.js
@@ -44,7 +44,7 @@ const definitions = [
     credentialItem: false,
   },
   {
-    identifier: 'cvc:Email:address',
+    identifier: 'cvc:Email:username',
     description: 'also known as email user',
     version: '1',
     type: 'String',
@@ -84,8 +84,8 @@ const definitions = [
           type: 'cvc:Email:domain',
         },
         {
-          name: 'address',
-          type: 'cvc:Email:address',
+          name: 'username',
+          type: 'cvc:Email:username',
         },
       ],
     },


### PR DESCRIPTION
By definition, an "Email Address" is the broader definition, and is is composed by `username @ domainname` (ref: https://techterms.com/definition/email_address). Calling the username part as "address" may create a confusion on future. This PR change `Email:address` to `Email:username`
