### PR TITLE
better email naming definition 2

### DIFF
--- a/__test__/uca/UserCollectableAttributes.test.js
+++ b/__test__/uca/UserCollectableAttributes.test.js
@@ -254,11 +254,11 @@ describe('UCA Constructions tests', () => {
 
   test('Construct a cvc:Contact:email UCA', () => {
     const identifier = 'cvc:Contact:email';
-    const email = new UCA(identifier, { address: 'joao', domain: { local_part: 'civic', tld: 'com' } });
+    const email = new UCA(identifier, { username: 'joao', domain: { name: 'civic', tld: 'com' } });
     const plain = email.getPlainValue();
-    expect(plain.address).toBe('joao');
+    expect(plain.username).toBe('joao');
     expect(plain.domain).toBeDefined();
-    expect(plain.domain.local_part).toBe('civic');
+    expect(plain.domain.name).toBe('civic');
     expect(plain.domain.tld).toBe('com');
   });
 
@@ -305,8 +305,8 @@ describe('UCA Constructions tests', () => {
     const emailDefinition = _.find(definitions, { identifier: 'cvc:Contact:email' });
     const properties = UCA.getUCAProperties(emailDefinition);
     expect(properties).toHaveLength(3);
-    expect(properties).toContain('email.address');
-    expect(properties).toContain('email.domain.local_part');
+    expect(properties).toContain('email.username');
+    expect(properties).toContain('email.domain.name');
     expect(properties).toContain('email.domain.tld');
   });
 

--- a/src/uca/definitions.js
+++ b/src/uca/definitions.js
@@ -31,20 +31,21 @@ const definitions = [
     attestable: true,
   },
   {
-    identifier: 'cvc:Domain:local_part',
-    description: 'also known as email domian',
+    identifier: 'cvc:Domain:name',
+    description: 'also known as email address domain',
     version: '1',
     type: 'String',
     credentialItem: false,
   },
   {
     identifier: 'cvc:Domain:tld',
+    description: 'also known as email address domain suffix, like .com, .org, .com.br',
     version: '1',
     type: 'String',
     credentialItem: false,
   },
   {
-    identifier: 'cvc:Email:address',
+    identifier: 'cvc:Email:username',
     description: 'also known as email user',
     version: '1',
     type: 'String',
@@ -60,11 +61,11 @@ const definitions = [
           type: 'cvc:Domain:tld',
         },
         {
-          name: 'local_part',
-          type: 'cvc:Domain:local_part',
+          name: 'name',
+          type: 'cvc:Domain:name',
         },
       ],
-      required: ['local_part', 'tld'],
+      required: ['name', 'tld'],
     },
     credentialItem: false,
   },
@@ -80,12 +81,12 @@ const definitions = [
     type: {
       properties: [
         {
-          name: 'domain',
-          type: 'cvc:Email:domain',
+          name: 'username',
+          type: 'cvc:Email:username',
         },
         {
-          name: 'address',
-          type: 'cvc:Email:address',
+          name: 'domain',
+          type: 'cvc:Email:domain',
         },
       ],
     },


### PR DESCRIPTION
This is another version for https://github.com/identity-com/credential-commons-js/pull/6, `local part` is used by some definition similar to `username` part of the email address (ref: https://en.wikipedia.org/wiki/Email_address). This PR changes `address` to `username` and domain `local_part` do domain `name`.