### PR TITLE
cvc:Email:username should be claimable (creadentialItem:true)

### DIFF
--- a/src/uca/definitions.js
+++ b/src/uca/definitions.js
@@ -49,7 +49,7 @@ const definitions = [
     description: 'also known as email user',
     version: '1',
     type: 'String',
-    credentialItem: false,
+    credentialItem: true,
   },
   {
     identifier: 'cvc:Type:domain',


### PR DESCRIPTION
as `cvc:Email:domain` is claimable (`creadentialItem:true`), so `cvc:Email:username` as well. Or am I missing something here?